### PR TITLE
Switch Gnosis Chain rpc, old one deprecated

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -5,7 +5,7 @@ const NETWORKS = {
     name: 'Gnosis Chain',
     symbol: 'XDAI',
     chainName: 'Gnosis Chain',
-    rpcUrl: 'https://dai.poa.network',
+    rpcUrl: 'https://rpc.gnosischain.com',
     blockExplorerUrl: 'https://blockscout.com/xdai/mainnet',
   },
   77: {


### PR DESCRIPTION
https://developers.gnosischain.com/for-developers/developer-resources/update-rpc-url

please also redeploy https://gbc-deposit-old.herokuapp.com/ with this fix, it isn't working anymore.