### PR TITLE
add updateExistngDeposits script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "lint-staged": "^11.1.2",
     "standard": "^16.0.3"
   },
+  "type": "module",
   "scripts": {
-    "build": "react-scripts build",
+    "updateExistingDeposits": "node ./src/scripts/updateExistngDeposits.js",
+    "build": "npm run updateExistingDeposits && react-scripts build",
     "predeploy": "npm run build",
     "lint": "standard",
     "lint:fix": "standard --fix",

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,36 +2,36 @@ const NETWORKS = {
   100: {
     forkVersion: "00000064",
     chainId: 100,
-    name: 'Gnosis Chain',
-    symbol: 'XDAI',
-    chainName: 'Gnosis Chain',
-    rpcUrl: 'https://rpc.gnosischain.com',
-    blockExplorerUrl: 'https://gnosisscan.io/',
-    beaconExplorerUrl: 'https://gnosischa.in',
+    name: "Gnosis Chain",
+    symbol: "XDAI",
+    chainName: "Gnosis Chain",
+    rpcUrl: "https://rpc.gnosischain.com",
+    blockExplorerUrl: "https://gnosisscan.io/",
+    beaconExplorerUrl: "https://gnosischa.in",
     addresses: {
-      wrapper: '0x647507A70Ff598F386CB96ae5046486389368C66',
-      token: '0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb',
-      deposit: '0x0B98057eA310F4d31F2a452B414647007d1645d9',
-      dappnodeDeposit: '0x6C68322cf55f5f025F2aebd93a28761182d077c3',
+      wrapper: "0x647507A70Ff598F386CB96ae5046486389368C66",
+      token: "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb",
+      deposit: "0x0B98057eA310F4d31F2a452B414647007d1645d9",
+      dappnodeDeposit: "0x6C68322cf55f5f025F2aebd93a28761182d077c3"
     },
-    depositStartBlockNumber: 22673201,
+    depositStartBlockNumber: 28820959
   },
   10200: {
     forkVersion: "0000006f",
     chainId: 10200,
-    name: 'Chiado',
-    symbol: 'CHI',
-    chainName: 'Chiado Testnet',
-    rpcUrl: 'https://rpc.chiadochain.net',
-    blockExplorerUrl: 'https://blockscout.chiadochain.net',
-    beaconExplorerUrl: 'https://beacon.chiadochain.net',
+    name: "Chiado",
+    symbol: "CHI",
+    chainName: "Chiado Testnet",
+    rpcUrl: "https://rpc.chiadochain.net",
+    blockExplorerUrl: "https://blockscout.chiadochain.net",
+    beaconExplorerUrl: "https://beacon.chiadochain.net",
     addresses: {
-      wrapper: '0x917947dC7E341d843ab38e91623bcAeb65512b75',
-      token: '0x19C653Da7c37c66208fbfbE8908A5051B57b4C70',
-      deposit: '0xb97036A26259B7147018913bD58a774cf91acf25',
-      dappnodeDeposit: null,
+      wrapper: "0x917947dC7E341d843ab38e91623bcAeb65512b75",
+      token: "0x19C653Da7c37c66208fbfbE8908A5051B57b4C70",
+      deposit: "0xb97036A26259B7147018913bD58a774cf91acf25",
+      dappnodeDeposit: null
     },
-    depositStartBlockNumber: 0,
+    depositStartBlockNumber: 0
   }
 }
 

--- a/src/scripts/updateExistngDeposits.js
+++ b/src/scripts/updateExistngDeposits.js
@@ -1,0 +1,80 @@
+import depositABI from '../abis/deposit.js'
+import { NETWORKS } from '../constants.js';
+import { Contract, ethers } from 'ethers'
+import path from 'path';
+import { readFile, writeFile } from 'fs/promises';
+
+const stepSize = 50000
+const maxConcurrency = 20
+async function getPastLogs(contract, event, { fromBlock, toBlock }, isFirstCall) {
+  const allEvents = []
+  const range = toBlock - fromBlock
+
+  if (isFirstCall) {
+    const chunkSize = Math.ceil((range) / maxConcurrency);
+    const promises = [];
+
+    for (let i = 0; i < maxConcurrency; i++) {
+      const startBlock = fromBlock + i * chunkSize;
+      let endBlock = startBlock + chunkSize - 1;
+      endBlock = endBlock < toBlock ? endBlock : toBlock
+      promises.push(getPastLogs(contract, event, { fromBlock: startBlock, toBlock: endBlock }, false));
+    }
+
+    const results = await Promise.all(promises);
+    results.forEach((result) => allEvents.push(...result));
+    return allEvents
+  }
+
+  for(;fromBlock < toBlock; fromBlock = fromBlock + stepSize) {
+    let stepBlock = fromBlock + stepSize - 1
+    stepBlock = stepBlock < toBlock ? stepBlock : toBlock
+    try {
+      const newEvents = await contract.queryFilter(event, fromBlock, stepBlock)
+      allEvents.push(...newEvents)
+    } catch (e) {
+      console.log(e)
+    }
+  }
+  return allEvents
+}
+
+async function main() {
+  const filePath = path.resolve(new URL(import.meta.url).pathname, '../../existing_deposits.json');
+  const existingDepositsString = await readFile(filePath, 'utf8')
+  let existingDeposits = JSON.parse(existingDepositsString);
+
+  const network = NETWORKS[100]
+  const provider = new ethers.providers.StaticJsonRpcProvider(network.rpcUrl)
+  const depositContract = new Contract(network.addresses.deposit, depositABI, provider)
+
+  console.log('Fetching existing deposits')
+  const fromBlock = parseInt(network.depositStartBlockNumber, 10) || 0
+  const toBlock = await provider.getBlockNumber()
+  const events = await getPastLogs(depositContract, 'DepositEvent', { fromBlock, toBlock }, true)
+
+  const pks = events.map(e => e.args.pubkey)
+  existingDeposits = existingDeposits.concat(pks)
+
+  // convert existingDeposits back to formatted json
+  let updatedExistingDepositsString = JSON.stringify(existingDeposits)
+  updatedExistingDepositsString = updatedExistingDepositsString.replaceAll('[', '[\n')
+  updatedExistingDepositsString = updatedExistingDepositsString.replaceAll(']', '\n]')
+  updatedExistingDepositsString = updatedExistingDepositsString.replaceAll(',', ',\n')
+  updatedExistingDepositsString = updatedExistingDepositsString.replaceAll('"0x', '\t"0x')
+  await writeFile(filePath, updatedExistingDepositsString, 'utf8');
+
+  // update depositStartBlockNumber and convert NETWORKS back to constants.js format
+  NETWORKS[100].depositStartBlockNumber = toBlock
+  let updatedNETWORKS = JSON.stringify(NETWORKS, null, "  ")
+  updatedNETWORKS = updatedNETWORKS.replaceAll('  "', '  ')
+  updatedNETWORKS = updatedNETWORKS.replaceAll('":', ':')
+  updatedNETWORKS = "const NETWORKS = " + updatedNETWORKS + "\n\nexport {\n  NETWORKS\n}"
+  
+  const filePathConstants = path.resolve(new URL(import.meta.url).pathname, '../../constants.js');
+  await writeFile(filePathConstants, updatedNETWORKS, 'utf8');
+
+  console.log(`Updated existing_deposits! Added ${pks.length} new cached pubkeys, new total is ${existingDeposits.length}.`)
+}
+
+main()


### PR DESCRIPTION
Updating `existing_deposits.json` is currently not a straightforward process.

Caused by issue #17, i was unable to deposit using the official UI. While working on a local fix, I implemented a script that updates the cached list of public keys (`pubkeys`). I integrated this script into the `package.json` scripts so that it automatically updates whenever a new version is built. The script utilizes the latest cache and appends any new public keys. Finally, it overwrites the existing files while trying to maintain a similar formatting style.

If you are interested, I would be glad to contribute this to the official repo. However, if not, please feel free to close this PR :) 